### PR TITLE
chore(#52) : tsconfig에서 JSX 파일 인식하도록 수정

### DIFF
--- a/GameNest/tsconfig.app.json
+++ b/GameNest/tsconfig.app.json
@@ -15,6 +15,11 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
+    /* JS/JSX 허용 */
+    "allowJs": true,
+    "checkJs": false,
+
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
@@ -23,5 +28,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  
+  "include": ["src", "src/**/*.jsx"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
tsconfig에서 JSX 파일 인식하도록 수정

allowJs: true: .js/.jsx 파일을 TS 프로젝트에 포함

checkJs: false: JS 파일까지 타입체크하지 않도록(팀에 따라 켤 수도 있지만, 보통은 끔)

include: 지금 "src"만으로도 잡히긴 하지만, .jsx를 명시해 두면 팀원 IDE 경고 줄이는 데 도움이 됩니다.

exclude: 빌드 출력/의존성 제외(선택이지만 안전)

tsconfig.json(루트)와 tsconfig.node.json은 그대로 두면 됩니다. 변경 대상은 앱용 tsconfig(app).